### PR TITLE
Update manifest.json to support BU 570

### DIFF
--- a/custom_components/medisanabp_ble/manifest.json
+++ b/custom_components/medisanabp_ble/manifest.json
@@ -5,6 +5,9 @@
     {
       "manufacturer_id": 18498,
       "connectable": true
+    },
+    {
+      "local_name": "1872B"
     }
   ],
   "codeowners": ["@bkbilly"],

--- a/custom_components/medisanabp_ble/manifest.json
+++ b/custom_components/medisanabp_ble/manifest.json
@@ -7,7 +7,8 @@
       "connectable": true
     },
     {
-      "local_name": "1872B"
+      "local_name": "1872B",
+      "connectable": true
     }
   ],
   "codeowners": ["@bkbilly"],


### PR DESCRIPTION
This change enables the detecting of the BU 570. I did some local testing with a custom script and the parser used in the component also seems to work fine with the BU 570, but for some reason home assistant is not able to connect to the device. Therefore, isn't able to read and parse the data.

the error:

```
[custom_components.medisanabp_ble] A4:C1:38:**:**:**: Bluetooth error whilst polling: A4:C1:38:**:**:** - A4:C1:38:**:**:**: Failed to connect after 5 attempt(s): Timeout waiting for connect response while connecting to A4:C1:38:**:**:** after 20.0s, disconnect timed out: False, after 20.0s
```

Some device details:

```
AdvertisementData(local_name='1872B', service_uuids=['00001810-0000-1000-8000-00805f9b34fb'], rssi=-64)
```

```
0000180a-0000-1000-8000-00805f9b34fb (Handle: 12): Device Information
   00002a29-0000-1000-8000-00805f9b34fb (Handle: 13): Manufacturer Name String
   00002a24-0000-1000-8000-00805f9b34fb (Handle: 15): Model Number String
   00002a25-0000-1000-8000-00805f9b34fb (Handle: 17): Serial Number String
   00002a27-0000-1000-8000-00805f9b34fb (Handle: 19): Hardware Revision String
   00002a26-0000-1000-8000-00805f9b34fb (Handle: 21): Firmware Revision String
   00002a28-0000-1000-8000-00805f9b34fb (Handle: 23): Software Revision String
   00002a23-0000-1000-8000-00805f9b34fb (Handle: 25): System ID
00001810-0000-1000-8000-00805f9b34fb (Handle: 27): Blood Pressure
   00002a35-0000-1000-8000-00805f9b34fb (Handle: 28): Blood Pressure Measurement
   00002a36-0000-1000-8000-00805f9b34fb (Handle: 31): Intermediate Cuff Pressure
   00002a49-0000-1000-8000-00805f9b34fb (Handle: 34): Blood Pressure Feature
0000180f-0000-1000-8000-00805f9b34fb (Handle: 36): Battery Service
   00002a19-0000-1000-8000-00805f9b34fb (Handle: 37): Battery Level
00001805-0000-1000-8000-00805f9b34fb (Handle: 40): Current Time Service
   00002a2b-0000-1000-8000-00805f9b34fb (Handle: 41): Current Time
```